### PR TITLE
Update documentation to reflect rfc8314.

### DIFF
--- a/docs/smtp/inbound/listeners.md
+++ b/docs/smtp/inbound/listeners.md
@@ -27,9 +27,9 @@ protocol = "smtp"
 greeting = "Welcome to Stalwart SMTP!"
 ```
 
-## SMTPS port
+## Submissions port (Native implicit TLS)
 
-SMTPS is a deprecated protocol that uses TLS encryption to secure SMTP connections. It is deprecated in favor of `STARTTLS`, which allows for opportunistic encryption of SMTP connections. SMTPS is received on port 465 by default. To enable SMTPS connections, create a listener with the following configuration:
+SMTP submissions with native implicit TLS are received on port 465 by default. This is the standard port for SMTP submissions with native implicit TLS, and is used by mail clients to send email to mail servers. To enable SMTP submissions with native implicit TLS, create a listener with the following configuration:
 
 ```toml
 [server.listener."submissions"]
@@ -38,15 +38,19 @@ protocol = "smtp"
 tls.implicit = true
 ```
 
-## Submissions port
+## Submissions port (StartTLS)
 
-SMTP submissions are received on port 587 by default. This is the standard port for SMTP submissions, and is used by mail clients to send email to mail servers. To enable SMTP submissions, create a listener with the following configuration:
+SMTP submissions with StartTLS are received on port 587 by default. This is the standard port for SMTP submissions with StartTLS, and is used by mail clients to send email to mail servers. To enable SMTP submissions, create a listener with the following configuration:
 
 ```toml
 [server.listener."submission"]
 bind = ["0.0.0.0:587"]
 protocol = "smtp"
 ```
+
+---
+#### Note : Since [RFC8314](https://tools.ietf.org/html/rfc8314), it is desirable to support both submissions over native implicit TLS and submissions over StartTLS for mail clients that dosen't support native implicit TLS yet. This same RFC incite however to prefer the use of submissions over native implicit TLS whenever possible as it's more secure.
+---
 
 ## LMTP port
 


### PR DESCRIPTION
TL;DR : Port 465 with implicit TLS for Submissions isn't outdated since RFC 8314

As stated in [RFC 8314](https://tools.ietf.org/html/rfc8314) : 
![image](https://user-images.githubusercontent.com/26208369/201494637-a9d70f67-89f9-4d89-b84d-c65b0ae2755a.png)

Also as stated [here](https://github.com/iredmail/iRedMail/issues/22#issuecomment-731779992) 

The IANA registry has been modified to register port 465 for native tls submissions connections : 

![image](https://user-images.githubusercontent.com/26208369/201494695-21b8f7a2-3243-44a6-80d2-93a46f67f399.png)