### PR TITLE
Fix typo

### DIFF
--- a/docs/smtp/authentication/dkim/sign.md
+++ b/docs/smtp/authentication/dkim/sign.md
@@ -66,7 +66,7 @@ To select which signature to use depending on the sender's domain, you can use a
 
 ```toml
 [auth.dkim]
-sign = [ { if = "is_local_domain('', sender-domain)", then = "'rsa_' + sender_domain" }, 
+sign = [ { if = "is_local_domain('', sender_domain)", then = "'rsa_' + sender_domain" }, 
          { else = false } ]
 ```
 


### PR DESCRIPTION
The example for selecting dynamic value based on the sender domain should be "sender_domain" instead of current example using "sender-domain" which results in server failing to start.