### PR TITLE
Correct `submission` port in "Getting started" section of the documentation

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -121,7 +121,7 @@ These records help mail clients such as Outlook or Thunderbird locate email serv
 SRV	_imap._tcp.example.org.	0 1 110 mail.example.org.
 SRV	_imaps._tcp.example.org.	0 1 993 mail.example.org.
 SRV	_submissions._tcp.example.org.	0 1 465 mail.example.org.
-SRV	_submission._tcp.example.org.	0 1 567 mail.example.org.
+SRV	_submission._tcp.example.org.	0 1 587 mail.example.org.
 ```
 
 These records facilitate [automatic configuration](/docs/server/autoconfig) of mail clients:


### PR DESCRIPTION
I am fairly certain that [`submission`](https://www.rfc-editor.org/rfc/rfc6409.html) is [port 587](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=587) 😄