### PR TITLE
change Documentation/Auth link to /docs/directory/overview

### DIFF
--- a/html/include-header.ejs
+++ b/html/include-header.ejs
@@ -115,7 +115,7 @@
                                                     href="/docs/storage/overview">Storage</a>
                                             </li>
                                             <li><a class="dropdown-item hover:!text-[#605dba]"
-                                                    href="/docs/auth/overview">Authentication</a></li>
+                                                    href="/docs/directory/overview">Authentication</a></li>
                                             <li><a class="dropdown-item hover:!text-[#605dba]"
                                                     href="/docs/encryption/overview">Encryption</a></li>
                                             <li><a class="dropdown-item hover:!text-[#605dba]"


### PR DESCRIPTION
The current Documentation/Authentication link in the header is broken. This pull request changes the link from `/docs/auth/overview` to `/docs/directory/overview`