### PR TITLE
Fix listen directive in nginx reverse proxy docs

### DIFF
--- a/docs/server/reverse-proxy/nginx.md
+++ b/docs/server/reverse-proxy/nginx.md
@@ -26,28 +26,28 @@ events {
 stream {
     # Proxy SMTP
     server {
-        listen 25 proxy_protocol;
+        listen 25;
         proxy_pass 127.0.0.1:10025;
         proxy_protocol on;
     }
 
     # Proxy IMAPS
     server {
-        listen 993 proxy_protocol;
+        listen 993;
         proxy_pass 127.0.0.1:10993;
         proxy_protocol on;
     }
 
     # Proxy SMTPS
     server {
-        listen 465 proxy_protocol;
+        listen 465;
         proxy_pass 127.0.0.1:10465;
         proxy_protocol on;
     }
 
     # Proxy HTTPS
     server {
-        listen 443 proxy_protocol;
+        listen 443;
         proxy_pass 127.0.0.1:10443;
         proxy_protocol on;
     }


### PR DESCRIPTION
The docs for a reverse proxy setup with nginx are wrong.

- `proxy_protocol` in the `listen` directive means that nginx expects to accept PROXY protocol on incoming connections.
- `proxy_protocol on` means PROXY protocol will be used for outgoing connections to the backend.

In a typical reverse proxy setup, you'd only need the latter to make nginx use the PROXY protocol to talk to Stalwart.