### PR TITLE
Example selector contains an underscore character that is not allowed

### DIFF
--- a/docs/smtp/authentication/dkim/sign.md
+++ b/docs/smtp/authentication/dkim/sign.md
@@ -43,7 +43,7 @@ Example:
 [signature."rsa"]
 private-key = "%{file:/opt/stalwart-smtp/etc/private/dkim-rsa.key}%"
 domain = "example.org"
-selector = "rsa_default"
+selector = "rsa-default"
 headers = ["From", "To", "Date", "Subject", "Message-ID"]
 algorithm = "rsa-sha256"
 canonicalization = "relaxed/relaxed"
@@ -54,7 +54,7 @@ report = true
 [signature."ed25519"]
 private-key = "%{file:/opt/stalwart-smtp/etc/private/dkim-ed.key}%"
 domain = "example.org"
-selector = "ed_default"
+selector = "ed-default"
 headers = ["From", "To", "Date", "Subject", "Message-ID"]
 algorithm = "ed25519-sha256"
 canonicalization = "simple/simple"


### PR DESCRIPTION
In this pull request, I've addressed an issue where an incorrect DKIM selector example was used in the repository (rsa_default and ed_default). The underscore character (_) is not a valid character for a DKIM selector, as it does not conform to the ABNF rules for valid sub-domain names defined in the relevant RFCs.

Relevant Standards:

RFC6376 Section 3.1: Defines a selector as a sub-domain that may include additional sub-domain components separated by dots.

RFC5321 Section 4.1.2: Specifies that a sub-domain must adhere to the following structure: sub-domain = Let-dig [Ldh-str]
Let-dig = ALPHA / DIGIT
Ldh-str = *( ALPHA / DIGIT / "-" ) Let-dig

RFC5234 Appendix B.1: Defines ALPHA and DIGIT:
ALPHA = %x41-5A / %x61-7A (A-Z, a-z)
DIGIT = %x30-39 (0-9)

Summary of Changes:

I updated the DKIM selector example to use only valid characters that comply with the applicable standards. This prevents users from mistakenly using an invalid selector in production.

Impact:
This change should help prevent configuration errors and subsequent DKIM verification failures that may arise from using non-compliant selectors.