### PR TITLE
Removal of RFC6652 Reporting Address (ra) modifier

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -94,8 +94,8 @@ TXT	202404r._domainkey.example.org.	v=DKIM1; k=rsa; h=sha256; p=MIIBIjANBgkqhkiG
 These records are used by the [Sender Policy Framework (SPF)](/docs/smtp/authentication/spf) to determine which mail servers are authorized to send emails on behalf of your domain:
 
 ```
-TXT	mail.example.org.	v=spf1 a ra=postmaster -all
-TXT	example.org.	v=spf1 mx ra=postmaster -all
+TXT	mail.example.org.	v=spf1 a -all
+TXT	example.org.	v=spf1 mx -all
 ```
 
 This record specifies the [Domain-based Message Authentication, Reporting, and Conformance (DMARC)](/docs/smtp/authentication/dmarc) security policy for email delivery and reporting:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -63,8 +63,8 @@ For example:
 MX  example.org.                      10 mail.example.org.
 TXT 202404e._domainkey.example.org.   v=DKIM1; k=ed25519; h=sha256; p=MCowBQYDK2VwAyEAOT2JN9F8SLTVFNEODDu22SD9RJDC282mugCAeXkzjH0=
 TXT 202404r._domainkey.example.org.   v=DKIM1; k=rsa; h=sha256; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAykeYJjv5N0AlnJ8gKF+/8qjbStiMFWvPg+p3JPh96GPXEN6l9W/Ee6Lag6i3vLyTVH5dnRVRBhfWhc+Dc0nKreZe4f5i4L5M4RI31+RpEgu4bCmncUIk2WzJgGBW5XbiOwXjge6OKWtJQN9d8Lc1AuryL5xeged9iS6xd/+EJz4WxAf18U+j38xmAm8fJUTBnQVeb/AZup+voSKAS59jyumsb0jQtXfX5xnwTFXdiX2OF8LRrmmNs/ObHozgHftxAv+YCiSU4bqSlKNPQIrN5kk1YnZDnLlc1Gr66AWlmdUVE7PWtZPTy4f8+uHO93EW3WUxLmynZm+Syn9FTJC2uwIDAQAB
-TXT mail.example.org.                 v=spf1 a -all ra=postmaster
-TXT example.org.                      v=spf1 mx -all ra=postmaster
+TXT mail.example.org.                 v=spf1 a -all
+TXT example.org.                      v=spf1 mx -all
 TXT _dmarc.example.org.               v=DMARC1; p=reject; rua=mailto:postmaster@example.org; ruf=mailto:postmaster@example.org
 ```
 

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -53,8 +53,8 @@ For example:
 MX  example.org.                      10 mail.example.org.
 TXT 202404e._domainkey.example.org.   v=DKIM1; k=ed25519; h=sha256; p=MCowBQYDK2VwAyEAOT2JN9F8SLTVFNEODDu22SD9RJDC282mugCAeXkzjH0=
 TXT 202404r._domainkey.example.org.   v=DKIM1; k=rsa; h=sha256; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAykeYJjv5N0AlnJ8gKF+/8qjbStiMFWvPg+p3JPh96GPXEN6l9W/Ee6Lag6i3vLyTVH5dnRVRBhfWhc+Dc0nKreZe4f5i4L5M4RI31+RpEgu4bCmncUIk2WzJgGBW5XbiOwXjge6OKWtJQN9d8Lc1AuryL5xeged9iS6xd/+EJz4WxAf18U+j38xmAm8fJUTBnQVeb/AZup+voSKAS59jyumsb0jQtXfX5xnwTFXdiX2OF8LRrmmNs/ObHozgHftxAv+YCiSU4bqSlKNPQIrN5kk1YnZDnLlc1Gr66AWlmdUVE7PWtZPTy4f8+uHO93EW3WUxLmynZm+Syn9FTJC2uwIDAQAB
-TXT mail.example.org.                 v=spf1 a -all ra=postmaster
-TXT example.org.                      v=spf1 mx -all ra=postmaster
+TXT mail.example.org.                 v=spf1 a -all
+TXT example.org.                      v=spf1 mx -all
 TXT _dmarc.example.org.               v=DMARC1; p=reject; rua=mailto:postmaster@example.org; ruf=mailto:postmaster@example.org
 ```
 

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -70,8 +70,8 @@ For example:
 MX  example.org.                      10 mail.example.org.
 TXT 202404e._domainkey.example.org.   v=DKIM1; k=ed25519; h=sha256; p=MCowBQYDK2VwAyEAOT2JN9F8SLTVFNEODDu22SD9RJDC282mugCAeXkzjH0=
 TXT 202404r._domainkey.example.org.   v=DKIM1; k=rsa; h=sha256; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAykeYJjv5N0AlnJ8gKF+/8qjbStiMFWvPg+p3JPh96GPXEN6l9W/Ee6Lag6i3vLyTVH5dnRVRBhfWhc+Dc0nKreZe4f5i4L5M4RI31+RpEgu4bCmncUIk2WzJgGBW5XbiOwXjge6OKWtJQN9d8Lc1AuryL5xeged9iS6xd/+EJz4WxAf18U+j38xmAm8fJUTBnQVeb/AZup+voSKAS59jyumsb0jQtXfX5xnwTFXdiX2OF8LRrmmNs/ObHozgHftxAv+YCiSU4bqSlKNPQIrN5kk1YnZDnLlc1Gr66AWlmdUVE7PWtZPTy4f8+uHO93EW3WUxLmynZm+Syn9FTJC2uwIDAQAB
-TXT mail.example.org.                 v=spf1 a -all ra=postmaster
-TXT example.org.                      v=spf1 mx -all ra=postmaster
+TXT mail.example.org.                 v=spf1 a -all
+TXT example.org.                      v=spf1 mx -all
 TXT _dmarc.example.org.               v=DMARC1; p=reject; rua=mailto:postmaster@example.org; ruf=mailto:postmaster@example.org
 ```
 


### PR DESCRIPTION
[RFC6652](https://datatracker.ietf.org/doc/html/rfc6652), introduced as an update to [RFC4408](https://datatracker.ietf.org/doc/html/rfc4408) in 2012, which was replaced by [RFC7208](https://datatracker.ietf.org/doc/html/rfc7208) in 2014, has gained little to no traction in the email ecosystem. I’ve yet to encounter any mail transfer agents (MTAs) that implement its modifiers or generate corresponding reports. In contrast, DMARC’s unified approach consolidates DKIM and SPF results into a single XML-based report, which has proven far more practical and widely adopted.

After scanning the SPF records of the world’s top 1 million domains, I found that only 15 contained the RFC6652 `ra` modifier—just 0.0015%. Additionally, the `rp` and `rr` modifiers from the same RFC were absent from any SPF records. While technically permissible within an SPF policy, encountering reports due to these modifiers seems unlikely.

Based on this data, I suspect the only records using the `ra=postmaster` modifier are directly influenced by this GitHub repository. Unless compelling evidence emerges showing that such reports are both generated and helpful beyond what DMARC aggregate reports already provide, I recommend reconsidering the inclusion of these modifiers in proposed SPF policies.