### PR TITLE
Correct nginx example

### DIFF
--- a/docs/server/reverse-proxy/nginx.md
+++ b/docs/server/reverse-proxy/nginx.md
@@ -26,28 +26,28 @@ events {
 stream {
     # Proxy SMTP
     server {
-        listen 25 proxy_protocol;
+        listen 25;
         proxy_pass 127.0.0.1:10025;
         proxy_protocol on;
     }
 
     # Proxy IMAPS
     server {
-        listen 993 proxy_protocol;
+        listen 993;
         proxy_pass 127.0.0.1:10993;
         proxy_protocol on;
     }
 
     # Proxy SMTPS
     server {
-        listen 465 proxy_protocol;
+        listen 465;
         proxy_pass 127.0.0.1:10465;
         proxy_protocol on;
     }
 
     # Proxy HTTPS
     server {
-        listen 443 proxy_protocol;
+        listen 443;
         proxy_pass 127.0.0.1:10443;
         proxy_protocol on;
     }


### PR DESCRIPTION
The "proxy_protocol" in the listen directive refers to incoming connections, that is, if you want to put nginx behind another proxy.

This results in errors like: "broken header: "<binary data>" while reading PROXY protocol".

Only "proxy_protocol on" is needed to make it generate those headers and send them to stalwart.