### PR TITLE
fix: incorrect link in top menu for Documentation / Logging

### DIFF
--- a/html/include-header.ejs
+++ b/html/include-header.ejs
@@ -138,7 +138,7 @@
                                             <li><a class="dropdown-item hover:!text-[#605dba]"
                                                     href="/docs/cluster/overview">Clustering</a></li>
                                             <li><a class="dropdown-item hover:!text-[#605dba]"
-                                                    href="/docs/tracing/overview">Logging</a>
+                                                    href="/docs/telemetry/overview">Telemetry</a>
                                             </li>
 
                                         </ul>


### PR DESCRIPTION
Open https://stalw.art/
Click in top menu on: Documentation -> Settings -> Logging
Result: 404

This change fixes that by updating the 'Logging' menu item to 'Telemetry', which is the top-level documentation entry - in line with the rest of the Documentation -> Settings subitems.