### PR TITLE
The example contains `addRcpt` which is actually `addRecipient`

### DIFF
--- a/docs/api/mta-hooks/response.md
+++ b/docs/api/mta-hooks/response.md
@@ -105,12 +105,12 @@ Below is an example of a response object:
             }
         },
         {
-            "type": "addRcpt",
+            "type": "addRecipient",
             "value": "tom@example.com",
             "parameters": null
         },
         {
-            "type": "deleteRcpt",
+            "type": "deleteRecipient",
             "value": "jane@foobar.com"
         },
         {


### PR DESCRIPTION
Source: https://github.com/stalwartlabs/stalwart/blob/55e62a683048d934a3890e86e6384c65fc29b0f2/crates/smtp/src/inbound/hooks/mod.rs#L168C23-L175