### PR TITLE
Fix `--console` argument order in example

### DIFF
--- a/docs/management/database.md
+++ b/docs/management/database.md
@@ -13,7 +13,7 @@ To start the database console, run the Stalwart binary with the `--console` para
 For example:
 
 ```bash
-$ /opt/stalwart/bin/stalwart --console --config /opt/stalwart/etc/config.toml
+$ /opt/stalwart/bin/stalwart --config /opt/stalwart/etc/config.toml --console
 ```
 
 This command initializes the console interface and establishes a connection to the configured backend database, providing an interactive session for executing database-related operations.


### PR DESCRIPTION
If the `--console` flag is passed first then it expects an argument, emitting `Missing value for argument 'console', try '--help'.`. If it is passed last then it works as expected.