### PR TITLE
Healthcheck with stalwart-cli

### DIFF
--- a/docs/cluster/orchestration/docker-swarm.md
+++ b/docs/cluster/orchestration/docker-swarm.md
@@ -84,7 +84,8 @@ services:
         - "traefik.http.routers.stalwart-jmap.service=stalwart-jmap"
         - "traefik.http.services.stalwart-jmap.loadbalancer.server.port=8000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "stalwart-cli", "-u", "http://localhost:8080/health", "-a",
+               "server", "healthcheck" ]
       interval: 1m
       timeout: 10s
       retries: 3


### PR DESCRIPTION
`stalwart-cli` goes in the container image, `curl` not.

The `-a` is for anonymous login, login without credentials.