### PR TITLE
fix(docs): Add missing block quote in alerts

### DIFF
--- a/docs/telemetry/alerts.md
+++ b/docs/telemetry/alerts.md
@@ -8,7 +8,7 @@ The Alerts feature in the Stalwart is designed to proactively notify administrat
 
 Alerts work by monitoring various server metrics and sending a notification when those metrics reach predefined thresholds. Notifications can be delivered via email or through a webhook, depending on your preference and the needs of your monitoring infrastructure. This flexibility allows you to integrate alerts seamlessly into your existing systems, ensuring that you receive timely information in the most convenient way possible.
 
-The condition that triggers an alert is configured using an expression that can combine one or multiple metrics. These expressions allow for complex conditions to be set, ensuring that alerts are only triggered when specific criteria are met. For example, an alert can be configured with an expression like server_memory > 1024 * 1024 * 1024 && queue_count > 5000, which would notify you if the server memory usage exceeds 1 GB while the message queue count surpasses 5,000. This capability to combine metrics into a single alert condition provides precise control over when and how you are notified.
+The condition that triggers an alert is configured using an expression that can combine one or multiple metrics. These expressions allow for complex conditions to be set, ensuring that alerts are only triggered when specific criteria are met. For example, an alert can be configured with an expression like `server_memory > 1024 * 1024 * 1024 && queue_count > 5000`, which would notify you if the server memory usage exceeds 1 GB while the message queue count surpasses 5,000. This capability to combine metrics into a single alert condition provides precise control over when and how you are notified.
 
 :::tip Enterprise feature
 


### PR DESCRIPTION
Currently it looks like this, where the `*` is interpreted as markdown: 
<img width="527" height="29" alt="image" src="https://github.com/user-attachments/assets/bb8429d6-6a26-47ec-9a7b-f27477cc8277" />
