### PR TITLE
Update dns.md SPF records

### DIFF
--- a/docs/install/dns.md
+++ b/docs/install/dns.md
@@ -35,8 +35,8 @@ Each DKIM record corresponds to a cryptographic key and is referenced by a selec
 The [Sender Policy Framework (SPF)](/docs/mta/authentication/spf) helps mail servers verify whether an email claiming to come from your domain was sent from an authorized server. SPF records are published as TXT records.
 
 ```
-TXT	mail.example.org.	v=spf1 a ra=postmaster -all
-TXT	example.org.	v=spf1 mx ra=postmaster -all
+TXT	mail.example.org.	v=spf1 a -all
+TXT	example.org.	v=spf1 mx -all
 ```
 
 These policies indicate that mail can be sent from the server defined by the domain’s MX or A records, and instruct recipient servers to reject emails from unauthorized sources.


### PR DESCRIPTION
Update for SPF records:

Default: 
v=spf1 a ra=postmaster -all is not valid syntax
v=spf1 mx ra=postmaster -all is not valid syntax

Proposal:
v=spf1 a -all
v=spf1 mx -all

or all in one: 
v=spf1 a mx -all
