### PR TITLE
Add documentation for WebSocket ticket-based authentication

### DIFF
--- a/docs/auth/oauth/tokens.md
+++ b/docs/auth/oauth/tokens.md
@@ -75,6 +75,7 @@ System administrators can configure under the `oauth.expiry` section the expirat
 - ``refresh-token-renew``:  Number of remaining seconds in a refresh token before a new one is issued to the client. Defaults to 345600 seconds (4 days).
 - ``user-code``: Expiration time in seconds of a user code issued by the device authentication flow. Defaults to 1800 seconds (30 minutes).
 - ``auth-code-expiry``: Expiration time in seconds of an authorization code issued by the authorization code flow. Defaults to 600 seconds (10 minutes).
+- ``ws-ticket``: Expiration time in seconds of a WebSocket authentication ticket. These short-lived tickets allow browser-based clients to authenticate WebSocket connections. Defaults to 60 seconds. See [WebSocket Ticket-Based Authentication](/docs/http/jmap/websockets#ticket-based-authentication) for more details.
 
 Example:
 
@@ -85,6 +86,7 @@ auth-code = "10m"
 token = "1h"
 refresh-token = "30d"
 refresh-token-renew = "4d"
+ws-ticket = "60s"
 ```
 
 The `oauth.auth.max-attempts` parameter can be used to prevent brute-force attacks against the authorization code flow. If the user fails to authenticate after the configured number of attempts, the authorization code is invalidated and the user has to start the flow again.

--- a/docs/http/jmap/websockets.md
+++ b/docs/http/jmap/websockets.md
@@ -14,6 +14,58 @@ When using JMAP over WebSocket, clients are only authenticated once when the con
 
 JMAP over WebSocket is enabled by default in Stalwart and is available to JMAP clients at `wss://your-domain.example`.
 
+## Ticket-Based Authentication
+
+Browser-based JMAP clients face a limitation when connecting to WebSockets: browsers do not allow setting custom HTTP headers (like `Authorization`) on WebSocket connections. To solve this, Stalwart supports ticket-based authentication for WebSocket connections.
+
+### How It Works
+
+1. **Obtain a ticket**: The client makes an authenticated `POST` request to `/jmap/ws/ticket` with a valid access token in the `Authorization` header.
+2. **Receive the ticket**: The server returns a short-lived ticket in the response: `{"value": "<ticket>"}`
+3. **Connect with the ticket**: The client connects to the WebSocket endpoint with the ticket as a query parameter: `wss://your-domain.example/jmap/ws?ticket=<ticket>`
+
+### Example
+
+```javascript
+// Step 1: Get a ticket using the access token
+const response = await fetch('https://mail.example.com/jmap/ws/ticket', {
+  method: 'POST',
+  headers: {
+    'Authorization': 'Bearer <access_token>'
+  }
+});
+const { value: ticket } = await response.json();
+
+// Step 2: Connect to WebSocket using the ticket
+const ws = new WebSocket(`wss://mail.example.com/jmap/ws?ticket=${ticket}`);
+```
+
+### Security
+
+- Tickets are short-lived (default: 60 seconds) to minimize the window for misuse
+- Tickets use the same encryption as OAuth access tokens
+- Each ticket is bound to the authenticated user's account
+- Rate limiting is applied to both ticket issuance and WebSocket connections
+
+The ticket expiry can be configured with the `oauth.expiry.ws-ticket` setting (see [OAuth Tokens](/docs/auth/oauth/tokens#expiration)).
+
+### Capability Advertisement
+
+The JMAP session response includes information about ticket authentication support:
+
+```json
+{
+  "capabilities": {
+    "urn:ietf:params:jmap:websocket": {
+      "url": "wss://mail.example.com/jmap/ws",
+      "supportsPush": true,
+      "supportsTicketAuth": true,
+      "ticketUrl": "https://mail.example.com/jmap/ws/ticket"
+    }
+  }
+}
+```
+
 ## Configuration
 
 The WebSocket following parameters can be configured under the `jmap.web-socket` section:


### PR DESCRIPTION
## Summary
Documents the new WebSocket ticket-based authentication feature introduced in stalwartlabs/stalwart#2678.

## Changes

### WebSockets documentation (`docs/http/jmap/websockets.md`)
- Added new "Ticket-Based Authentication" section explaining:
  - How the ticket flow works (obtain ticket → connect with ticket)
  - JavaScript code example for browser clients
  - Security considerations (short TTL, encryption, rate limiting)
  - Capability advertisement in JMAP session response

### OAuth Tokens documentation (`docs/auth/oauth/tokens.md`)
- Added `ws-ticket` to the expiry configuration options
- Updated the example configuration block

## Related
- Implementation PR: stalwartlabs/stalwart#2678
- Issue: stalwartlabs/stalwart#2677

🤖 Generated with [Claude Code](https://claude.com/claude-code)