### PR TITLE
Add to caddy required settings

### DIFF
--- a/docs/server/reverse-proxy/caddy.md
+++ b/docs/server/reverse-proxy/caddy.md
@@ -137,4 +137,5 @@ server.tls.certificate = "default"
 certificate.default.cert = "%{file:/opt/stalwart/cert/example.com.pem}%"
 certificate.default.default = true
 certificate.default.private-key = "%{file:/opt/stalwart/cert/example.com.priv.pem}%"
+server.proxy.trusted-networks = ["::1","127.0.0.0/8", "172.16.0.0/12","192.168.0.0/24", "10.0.0.0/8"]
 ```

--- a/docs/server/reverse-proxy/caddy.md
+++ b/docs/server/reverse-proxy/caddy.md
@@ -66,16 +66,6 @@ The following is an example of a Caddyfile configuration that can be used to set
     }
 }
 
-example.com {
-    redir https://www.example.com{uri}
-}
-
-www.example.com {
-    root * /var/www/imkerei
-
-    file_server
-}
-
 mail.example.com {
     reverse_proxy https://127.0.0.1:10443 {
         transport http {


### PR DESCRIPTION
After not being able to access my server on https (only http), looking thru the discord yielded:
https://discord.com/channels/923615863037390889/1208096676892381294/threads/1283379830716366862

Of which the fix  is this pr