### PR TITLE
docs: correct npm package name in installation instructions

### DIFF
--- a/src/content/docs/docs/management/cli/index.md
+++ b/src/content/docs/docs/management/cli/index.md
@@ -46,7 +46,7 @@ brew install stalwartlabs/tap/stalwart-cli
 ### npm (Node.js, all platforms)
 
 ```sh
-npm install -g @stalwartlabs/cli
+npm install -g stalwart-cli
 ```
 
 ### Windows MSI


### PR DESCRIPTION
docs: fix incorrect npm install command

The documentation incorrectly specified @stalwartlabs/cli as the package name,
but the actual package on npm is stalwart-cli.

Ref: https://www.npmjs.com/package/stalwart-cli