### PR TITLE
Fix available option listing for DMARC and TLS reporting frequency

### DIFF
--- a/src/content/docs/docs/mta/reports/dmarc.md
+++ b/src/content/docs/docs/mta/reports/dmarc.md
@@ -42,7 +42,7 @@ Aggregate reports are configured by the following fields:
 - [`aggregateSubject`](/docs/ref/object/dmarc-report-settings#aggregatesubject): expression returning the report subject. Default `'DMARC Aggregate Report'`.
 - [`aggregateOrgName`](/docs/ref/object/dmarc-report-settings#aggregateorgname): expression returning the organisation name included in the report. Default `system('domain')`.
 - [`aggregateContactInfo`](/docs/ref/object/dmarc-report-settings#aggregatecontactinfo): optional expression returning contact information for the reporting organisation.
-- [`aggregateSendFrequency`](/docs/ref/object/dmarc-report-settings#aggregatesendfrequency): expression returning the frequency at which aggregate reports are sent. Supported values are `hourly`, `daily`, `weekly`, and `never`. Default `daily`.
+- [`aggregateSendFrequency`](/docs/ref/object/dmarc-report-settings#aggregatesendfrequency): expression returning the frequency at which aggregate reports are sent. Supported values are `hourly`, `daily`, `weekly`, and `disable`. Default `daily`.
 - [`aggregateMaxReportSize`](/docs/ref/object/dmarc-report-settings#aggregatemaxreportsize): expression returning the maximum size of the aggregate report in bytes. Default 5242880 (5 MB).
 - [`aggregateDkimSignDomain`](/docs/ref/object/dmarc-report-settings#aggregatedkimsigndomain): expression returning the domain whose DKIM signatures sign the outgoing report. Default `system('domain')`.
 

--- a/src/content/docs/docs/mta/reports/tls.md
+++ b/src/content/docs/docs/mta/reports/tls.md
@@ -14,7 +14,7 @@ Stalwart [automatically analyses](/docs/mta/reports/analysis) TLS reports receiv
 - [`subject`](/docs/ref/object/tls-report-settings#subject): expression returning the report subject. Default `'TLS Aggregate Report'`.
 - [`orgName`](/docs/ref/object/tls-report-settings#orgname): expression returning the organisation name included in the report. Default `system('domain')`.
 - [`contactInfo`](/docs/ref/object/tls-report-settings#contactinfo): optional expression returning contact information for the reporting organisation.
-- [`sendFrequency`](/docs/ref/object/tls-report-settings#sendfrequency): expression returning the frequency at which aggregate reports are sent. Supported values are `hourly`, `daily`, `weekly`, and `never`. Default `daily`.
+- [`sendFrequency`](/docs/ref/object/tls-report-settings#sendfrequency): expression returning the frequency at which aggregate reports are sent. Supported values are `hourly`, `daily`, `weekly`, and `disable`. Default `daily`.
 - [`maxReportSize`](/docs/ref/object/tls-report-settings#maxreportsize): expression returning the maximum report size in bytes. Default 5242880 (5 MB).
 - [`dkimSignDomain`](/docs/ref/object/tls-report-settings#dkimsigndomain): expression returning the domain whose [DKIM](/docs/mta/authentication/dkim/) signatures sign the outgoing report. Default `system('domain')`.
 


### PR DESCRIPTION
Currently both in the dmarc and tls reporting docs it says, that to disable them you should input "never". "never" is however not accepted. The correct value (which also shows in the web-ui) is "disabled".

This MR fixes this inconsistency in the docs.